### PR TITLE
feat: expose per-member action & interaction data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,15 @@ execution_engine.offer_land(me, target)  # transfer land tiles
 execution_engine.send_message(me.id, target.id, "let's trade")
 ```
 
-**Member attributes (read-only):** `member.id`, `member.vitality` (0-100), `member.cargo`, `member.land_num`
+**Member attributes (read-only):** `member.id`, `member.vitality` (0-100), `member.cargo`, `member.land_num`, `member.age`, `member.productivity`
+
+**Previous round activity (read-only, set each round):**
+- `member.last_round_actions` — `{"expand": N, "attack": N, "offer": N, "offer_land": N}`
+- `member.last_round_attacks_made` — `{target_id: damage_dealt}`
+- `member.last_round_offers_made` — `{target_id: amount_given}`
+- `member.last_round_attacks_received` — `{attacker_id: damage_taken}`
+- `member.last_round_offers_received` — `{giver_id: amount_received}`
+- `member.interaction_memory` — cumulative decay-weighted history (keys: attack_made, attack_received, benefit_given, benefit_received, land_given, land_received)
 
 **Constraints:** 5-second timeout, no network, no file I/O, no imports beyond `math`/`json`.
 
@@ -271,7 +279,7 @@ Content-Type: application/json
 | Mechanism | Code Pattern |
 |-----------|-------------|
 | Vitality floor | `if m.vitality < 15: m.vitality += 5` |
-| Trade incentive | `if m.last_action == 'offer': m.vitality += 3` |
+| Trade incentive | `if m.last_round_actions["offer"] > 0: m.vitality += 3` |
 | Production boost | `m.cargo = m.cargo * 1.05` |
 | Progressive tax | `if m.cargo > avg: m.cargo -= (m.cargo - avg) * 0.1` |
 | Anti-monopoly | `if m.land_num > max_fair: redistribute()` |

--- a/Leviathan/Island.py
+++ b/Leviathan/Island.py
@@ -1604,6 +1604,33 @@ class Island():
         _apply_update("reproduce", "reproduce")
         _apply_update("clear", "clear")
 
+        # ── Stamp per-member round summary for mechanism code access ──
+        living_ids = {m.id for m in self.current_members}
+        for member in self.current_members:
+            counts = action_counts.get(member.id, {})
+            member.last_round_actions = {
+                "expand": int(counts.get("clear", 0)),
+                "attack": int(counts.get("attack", 0)),
+                "offer": int(counts.get("offer", 0)),
+                "offer_land": int(counts.get("offer_land", 0)),
+            }
+            member.last_round_attacks_made = {}
+            member.last_round_attacks_received = {}
+            member.last_round_offers_made = {}
+            member.last_round_offers_received = {}
+
+        for (m1, m2), val in self.round_action_dict.get("attack", {}).items():
+            if m1 in living_ids:
+                self.all_members[m1].last_round_attacks_made[m2] = round(float(val), 2)
+            if m2 in living_ids:
+                self.all_members[m2].last_round_attacks_received[m1] = round(float(val), 2)
+
+        for (m1, m2), val in self.round_action_dict.get("benefit", {}).items():
+            if m1 in living_ids:
+                self.all_members[m1].last_round_offers_made[m2] = round(float(val), 2)
+            if m2 in living_ids:
+                self.all_members[m2].last_round_offers_received[m1] = round(float(val), 2)
+
         # 更新下一轮快照
         self._round_snapshot = {
             member.id: (member.vitality, member.cargo, member.land_num)

--- a/Leviathan/Member.py
+++ b/Leviathan/Member.py
@@ -410,6 +410,13 @@ class Member():
             "land_received": defaultdict(float),
             "land_given": defaultdict(float),
         }
+        # Per-round action summary (stamped by Island._update_member_learning_and_memory)
+        self.last_round_actions = {"expand": 0, "attack": 0, "offer": 0, "offer_land": 0}
+        self.last_round_attacks_made = {}    # {target_id: damage}
+        self.last_round_attacks_received = {}  # {attacker_id: damage}
+        self.last_round_offers_made = {}     # {target_id: amount}
+        self.last_round_offers_received = {}   # {giver_id: amount}
+
         self._apply_profile_scaling()
 
     def __str__(self):

--- a/MetaIsland/base_member.py
+++ b/MetaIsland/base_member.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from collections import defaultdict
 import numpy as np
 import pandas as pd
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -148,6 +149,23 @@ class Member():
         self.cargo = self._rng.uniform(Member._INIT_MIN_CARGO, Member._INIT_MAX_CARGO)
         self.age = int(self._rng.uniform(Member._INIT_MIN_AGE, Member._INIT_MAX_AGE))
 
+        # Per-round action summary (stamped by Island._stamp_member_action_summaries)
+        self.last_round_actions = {"expand": 0, "attack": 0, "offer": 0, "offer_land": 0}
+        self.last_round_attacks_made = {}    # {target_id: damage}
+        self.last_round_attacks_received = {}  # {attacker_id: damage}
+        self.last_round_offers_made = {}     # {target_id: amount}
+        self.last_round_offers_received = {}   # {giver_id: amount}
+
+        # Cumulative interaction memory (decay-weighted)
+        self.interaction_memory = {
+            "attack_received": defaultdict(float),
+            "attack_made": defaultdict(float),
+            "benefit_received": defaultdict(float),
+            "benefit_given": defaultdict(float),
+            "land_received": defaultdict(float),
+            "land_given": defaultdict(float),
+        }
+
     def __str__(self):
         """重载print函数表示"""
         return colored(self._current_color, f"{self.name}({self.id})")
@@ -155,7 +173,11 @@ class Member():
     def __repr__(self):
         """重载其他print形式的表示"""
         return self.__str__()
-        
+
+    def record_interaction(self, kind: str, other_id: int, value: float) -> None:
+        if kind in self.interaction_memory:
+            self.interaction_memory[kind][other_id] += value
+
 # ##############################################################################
 # ##################################### 状态 ####################################
     

--- a/docs/personas/diplomat.md
+++ b/docs/personas/diplomat.md
@@ -117,7 +117,7 @@ MECHANISMS = [
      "desc": "Trade incentive: members who offer resources gain +3 vitality bonus",
      "code": """def propose_modification(execution_engine):
     for m in execution_engine.current_members:
-        if getattr(m, 'last_action', '') == 'offer':
+        if m.last_round_actions.get('offer', 0) > 0:
             m.vitality = min(m.vitality + 3.0, 100.0)
 """},
     {"trigger": lambda m, p, g: p < 25,
@@ -203,6 +203,10 @@ def run():
 if __name__ == "__main__":
     run()
 ```
+
+## Available Member Attributes for Mechanism Code
+
+See [AGENTS.md Section 9](../../AGENTS.md#9-execution-engine-api-sandbox-reference) for the full list of member attributes available in mechanism code, including `last_round_actions`, attack/offer details, and `interaction_memory`.
 
 ## Customizing
 

--- a/docs/personas/expansionist.md
+++ b/docs/personas/expansionist.md
@@ -174,6 +174,10 @@ if __name__ == "__main__":
     run()
 ```
 
+## Available Member Attributes for Mechanism Code
+
+See [AGENTS.md Section 9](../../AGENTS.md#9-execution-engine-api-sandbox-reference) for the full list of member attributes available in mechanism code, including `last_round_actions`, attack/offer details, and `interaction_memory`.
+
 ## Customizing
 
 - **More aggressive:** Lower the vitality threshold for attacks (e.g., `vit > 40` instead of `vit > 60`)

--- a/docs/personas/llm-powered.md
+++ b/docs/personas/llm-powered.md
@@ -56,6 +56,8 @@ curl -s -X POST "$BASE/v1/world/mechanisms/propose" \
   -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
   -d '{"code": "def propose_modification(execution_engine):\n    ...", "description": "...", "idempotency_key": "round-'$ROUND'-mech"}'
 
+> **Member attributes available in mechanism code:** See [AGENTS.md Section 9](../../AGENTS.md#9-execution-engine-api-sandbox-reference) for all attributes including `last_round_actions`, attack/offer details, and `interaction_memory`.
+
 ### 4. Update memory
 cat > "$MEMORY_FILE" << 'MEMEOF'
 [your analysis, decisions, plans]

--- a/docs/personas/strategist.md
+++ b/docs/personas/strategist.md
@@ -230,6 +230,10 @@ if __name__ == "__main__":
     run()
 ```
 
+## Available Member Attributes for Mechanism Code
+
+See [AGENTS.md Section 9](../../AGENTS.md#9-execution-engine-api-sandbox-reference) for the full list of member attributes available in mechanism code, including `last_round_actions`, attack/offer details, and `interaction_memory`.
+
 ## Customizing
 
 - **Trend sensitivity:** Change `deque(maxlen=10)` for longer/shorter memory

--- a/kernel/world_kernel.py
+++ b/kernel/world_kernel.py
@@ -105,6 +105,22 @@ class WorldKernel:
                     member_dict["consumption"] = float(m.consumption)
                 if hasattr(m, "overall_productivity"):
                     member_dict["overall_productivity"] = float(m.overall_productivity)
+                # Action summary from previous round
+                if hasattr(m, "last_round_actions"):
+                    member_dict["last_round_actions"] = m.last_round_actions
+                    member_dict["last_round_attacks_made"] = getattr(m, "last_round_attacks_made", {})
+                    member_dict["last_round_attacks_received"] = getattr(m, "last_round_attacks_received", {})
+                    member_dict["last_round_offers_made"] = getattr(m, "last_round_offers_made", {})
+                    member_dict["last_round_offers_received"] = getattr(m, "last_round_offers_received", {})
+                # Cumulative interaction memory (decay-weighted)
+                if hasattr(m, "interaction_memory"):
+                    member_dict["interaction_memory"] = {
+                        k: {str(k2): round(v2, 2) for k2, v2 in v.items() if v2 > 0.01}
+                        for k, v in m.interaction_memory.items()
+                    }
+                # Strategy profile
+                if hasattr(m, "strategy_profile"):
+                    member_dict["strategy_profile"] = m.strategy_profile
                 members.append(member_dict)
 
             land_info = {"shape": list(self._execution.land.shape)}

--- a/scripts/agents/prompts/diplomat_round.md
+++ b/scripts/agents/prompts/diplomat_round.md
@@ -52,6 +52,14 @@ Design mechanisms that are **genuinely novel and responsive to the actual world 
 
 The mechanism code must define `def propose_modification(execution_engine):` and can modify member attributes (vitality, cargo) or create new dynamics.
 
+#### Available Member Attributes (in mechanism code)
+Inside `propose_modification(execution_engine)`, each `m` in `execution_engine.current_members`:
+- Core: `m.vitality`, `m.cargo`, `m.land_num`, `m.age`, `m.productivity`
+- Last round actions: `m.last_round_actions` → {"expand": N, "attack": N, "offer": N, "offer_land": N}
+- Attack detail: `m.last_round_attacks_made` → {target_id: damage}, `m.last_round_attacks_received` → {attacker_id: damage}
+- Offer detail: `m.last_round_offers_made` → {target_id: amount}, `m.last_round_offers_received` → {giver_id: amount}
+- History: `m.interaction_memory["benefit_given"]` → {other_id: cumulative_amount} (also: attack_made, attack_received, benefit_received, land_given, land_received)
+
 **Creative mechanism ideas to consider:**
 - Progressive taxation: members with vitality > X contribute to a pool that goes to members below Y
 - Cooperation multiplier: members who offered this round get +N% production bonus

--- a/scripts/agents/prompts/expansionist_round.md
+++ b/scripts/agents/prompts/expansionist_round.md
@@ -46,6 +46,14 @@ Don't propose every round — only when the world state shows a clear need:
 
 Be creative. Design mechanisms that benefit expansion-oriented agents but don't obviously harm others (so they pass the vote). The mechanism code must define `def propose_modification(execution_engine):` and can modify any member attributes or world state.
 
+#### Available Member Attributes (in mechanism code)
+Inside `propose_modification(execution_engine)`, each `m` in `execution_engine.current_members`:
+- Core: `m.vitality`, `m.cargo`, `m.land_num`, `m.age`, `m.productivity`
+- Last round actions: `m.last_round_actions` → {"expand": N, "attack": N, "offer": N, "offer_land": N}
+- Attack detail: `m.last_round_attacks_made` → {target_id: damage}, `m.last_round_attacks_received` → {attacker_id: damage}
+- Offer detail: `m.last_round_offers_made` → {target_id: amount}, `m.last_round_offers_received` → {giver_id: amount}
+- History: `m.interaction_memory["benefit_given"]` → {other_id: cumulative_amount} (also: attack_made, attack_received, benefit_received, land_given, land_received)
+
 ```bash
 curl -s -X POST "$BASE/v1/world/mechanisms/propose" \
   -H "X-API-Key: $API_KEY" \

--- a/scripts/agents/prompts/strategist_round.md
+++ b/scripts/agents/prompts/strategist_round.md
@@ -49,6 +49,14 @@ Only propose when you see a clear data-driven opportunity:
 
 Design mechanisms that are subtle — they should look fair but give a strategic edge to adaptive players like you.
 
+#### Available Member Attributes (in mechanism code)
+Inside `propose_modification(execution_engine)`, each `m` in `execution_engine.current_members`:
+- Core: `m.vitality`, `m.cargo`, `m.land_num`, `m.age`, `m.productivity`
+- Last round actions: `m.last_round_actions` → {"expand": N, "attack": N, "offer": N, "offer_land": N}
+- Attack detail: `m.last_round_attacks_made` → {target_id: damage}, `m.last_round_attacks_received` → {attacker_id: damage}
+- Offer detail: `m.last_round_offers_made` → {target_id: amount}, `m.last_round_offers_received` → {giver_id: amount}
+- History: `m.interaction_memory["benefit_given"]` → {other_id: cumulative_amount} (also: attack_made, attack_received, benefit_received, land_given, land_received)
+
 ```bash
 curl -s -X POST "$BASE/v1/world/mechanisms/propose" \
   -H "X-API-Key: $API_KEY" \

--- a/scripts/agents/summarize_state.py
+++ b/scripts/agents/summarize_state.py
@@ -62,6 +62,29 @@ def summarize(snapshot: dict, metrics: dict, member_id: int, mechanisms: list) -
         marker = " ← YOU" if m["id"] == member_id else ""
         lines.append(f"- id={m['id']}: vit={m['vitality']:.1f} cargo={m['cargo']:.1f} land={m['land_num']}{marker}")
 
+    # Last round activity
+    active_members = []
+    for m in members:
+        actions = m.get("last_round_actions")
+        if not actions:
+            continue
+        parts = []
+        if actions.get("expand", 0) > 0:
+            parts.append("expanded")
+        atk_made = m.get("last_round_attacks_made", {})
+        for tid, dmg in atk_made.items():
+            parts.append(f"attacked→{tid} ({dmg})")
+        offers_made = m.get("last_round_offers_made", {})
+        for tid, amt in offers_made.items():
+            parts.append(f"offered→{tid} ({amt})")
+        if parts:
+            active_members.append((m["id"], parts))
+    if active_members:
+        lines.append(f"\n### Last Round Activity")
+        for mid, parts in active_members:
+            marker = " ← YOU" if mid == member_id else ""
+            lines.append(f"- id={mid}: {', '.join(parts)}{marker}")
+
     # Pending mechanisms
     if mechanisms:
         lines.append(f"\n### Pending Mechanisms ({len(mechanisms)} needing your vote)")

--- a/tests/test_action_exposure.py
+++ b/tests/test_action_exposure.py
@@ -1,0 +1,182 @@
+"""Tests for per-member action summaries and interaction data exposure."""
+import pytest
+
+from kernel.schemas import WorldConfig
+from kernel.world_kernel import WorldKernel
+from kernel.execution_sandbox import InProcessSandbox, SandboxContext
+from MetaIsland.metaIsland import IslandExecution
+
+
+@pytest.fixture
+def island(tmp_path):
+    """Create a small island with 3 members for testing."""
+    return IslandExecution(
+        init_member_number=3,
+        land_shape=(5, 5),
+        save_path=str(tmp_path),
+        random_seed=42,
+    )
+
+
+@pytest.fixture
+def world_kernel(tmp_path):
+    """Create a WorldKernel with 3 members."""
+    config = WorldConfig(init_member_number=3, land_shape=(5, 5), random_seed=42)
+    return WorldKernel(config, save_path=str(tmp_path))
+
+
+class TestLastRoundActions:
+    def test_last_round_actions_populated(self, island):
+        """After actions, new_round stamps action counts on members."""
+        m0, m1, m2 = island.current_members[0], island.current_members[1], island.current_members[2]
+
+        # Simulate: m0 attacks m1, m2 attacks m0
+        island.record_action_dict["attack"][(m0.id, m1.id)] = 5.0
+        island.record_action_dict["attack"][(m2.id, m0.id)] = 3.0
+        # Simulate expand via _expand_counts
+        island._expand_counts[m0.id] = 2
+        island._expand_counts[m2.id] = 1
+
+        island.new_round()
+
+        assert m0.last_round_actions["attack"] == 1
+        assert m0.last_round_actions["expand"] == 2
+        assert m0.last_round_actions["offer"] == 0
+        assert m1.last_round_actions["attack"] == 0
+        assert m2.last_round_actions["expand"] == 1
+        assert m2.last_round_actions["attack"] == 1
+
+    def test_offer_details_populated(self, island):
+        """Offer actions populate made/received dicts with correct IDs and amounts."""
+        m0, m1 = island.current_members[0], island.current_members[1]
+
+        island.record_action_dict["benefit"][(m0.id, m1.id)] = 12.5
+
+        island.new_round()
+
+        assert m0.last_round_offers_made == {m1.id: 12.5}
+        assert m1.last_round_offers_received == {m0.id: 12.5}
+        assert m0.last_round_offers_received == {}
+        assert m1.last_round_offers_made == {}
+
+    def test_attack_details_populated(self, island):
+        """Attack actions populate made/received dicts with correct IDs and amounts."""
+        m0, m1 = island.current_members[0], island.current_members[1]
+
+        island.record_action_dict["attack"][(m0.id, m1.id)] = 15.3
+
+        island.new_round()
+
+        assert m0.last_round_attacks_made == {m1.id: 15.3}
+        assert m1.last_round_attacks_received == {m0.id: 15.3}
+        assert m0.last_round_attacks_received == {}
+        assert m1.last_round_attacks_made == {}
+
+    def test_action_data_survives_new_round(self, island):
+        """Attributes persist after new_round() since stamping happens before reset."""
+        m0, m1 = island.current_members[0], island.current_members[1]
+
+        island.record_action_dict["attack"][(m0.id, m1.id)] = 7.0
+
+        # new_round stamps data then clears record_action_dict
+        island.new_round()
+
+        assert m0.last_round_actions["attack"] == 1
+        assert m0.last_round_attacks_made == {m1.id: 7.0}
+        assert m1.last_round_attacks_received == {m0.id: 7.0}
+
+        # Verify records were cleared
+        assert island.record_action_dict["attack"] == {}
+
+    def test_expand_tracked_via_expand_method(self, island):
+        """Calling expand() on a member tracks the expand count."""
+        m0 = island.current_members[0]
+        # Try to expand (may or may not succeed depending on land availability)
+        island.expand(m0)
+
+        # Check that _expand_counts was updated (if expansion succeeded)
+        if island._expand_counts.get(m0.id, 0) > 0:
+            island.new_round()
+            assert m0.last_round_actions["expand"] >= 1
+
+
+class TestSnapshotExposure:
+    def test_snapshot_includes_action_data(self, world_kernel):
+        """WorldKernel.get_snapshot() includes per-member action fields."""
+        snap = world_kernel.get_snapshot()
+
+        for member_dict in snap.members:
+            assert "last_round_actions" in member_dict
+            assert set(member_dict["last_round_actions"].keys()) == {
+                "expand", "attack", "offer", "offer_land"
+            }
+            assert "last_round_attacks_made" in member_dict
+            assert "last_round_attacks_received" in member_dict
+            assert "last_round_offers_made" in member_dict
+            assert "last_round_offers_received" in member_dict
+
+    def test_interaction_memory_in_snapshot(self, world_kernel):
+        """interaction_memory appears in snapshot with correct structure."""
+        engine = world_kernel._execution
+        m0, m1 = engine.current_members[0], engine.current_members[1]
+
+        # Record interactions and stamp via new_round
+        engine.record_action_dict["attack"][(m0.id, m1.id)] = 10.0
+        engine.new_round()
+
+        snap = world_kernel.get_snapshot()
+        m0_snap = next(m for m in snap.members if m["id"] == m0.id)
+
+        assert "interaction_memory" in m0_snap
+        im = m0_snap["interaction_memory"]
+        assert "attack_made" in im
+        assert str(m1.id) in im["attack_made"]
+
+    def test_snapshot_action_data_after_actions(self, world_kernel):
+        """Snapshot reflects actual action data after round with actions."""
+        engine = world_kernel._execution
+        m0, m1 = engine.current_members[0], engine.current_members[1]
+
+        engine.record_action_dict["benefit"][(m0.id, m1.id)] = 8.0
+        engine.new_round()
+
+        snap = world_kernel.get_snapshot()
+        m0_snap = next(m for m in snap.members if m["id"] == m0.id)
+        m1_snap = next(m for m in snap.members if m["id"] == m1.id)
+
+        assert m0_snap["last_round_actions"]["offer"] == 1
+        assert m0_snap["last_round_offers_made"] == {m1.id: 8.0}
+        assert m1_snap["last_round_offers_received"] == {m0.id: 8.0}
+
+
+class TestMechanismAccess:
+    def test_mechanism_can_read_action_data(self, island):
+        """Mechanism code can read last_round_actions and modify vitality."""
+        m0, m1 = island.current_members[0], island.current_members[1]
+
+        # Simulate m0 offered last round
+        island.record_action_dict["benefit"][(m0.id, m1.id)] = 5.0
+        island.new_round()
+
+        assert m0.last_round_actions["offer"] == 1
+
+        # Record m1's vitality before mechanism
+        m1_vit_before = m1.vitality
+
+        # Run mechanism code that reads action data
+        code = (
+            "def propose_modification(execution_engine):\n"
+            "    for m in execution_engine.current_members:\n"
+            "        if m.last_round_actions.get('offer', 0) > 0:\n"
+            "            m.vitality += 5\n"
+        )
+
+        vit_before = m0.vitality
+        sandbox = InProcessSandbox()
+        ctx = SandboxContext(execution_engine=island, member_index=0)
+        result = sandbox.execute_mechanism_code(code, ctx)
+
+        assert result.success, f"Mechanism failed: {result.error}"
+        assert m0.vitality == pytest.approx(vit_before + 5)
+        # m1 didn't offer, so no bonus
+        assert m1.vitality == pytest.approx(m1_vit_before)


### PR DESCRIPTION
## Summary
- Stamp `last_round_actions`, attack/offer detail dicts, and `interaction_memory` on Member objects so mechanism code can reference them (e.g. `m.last_round_actions["offer"] > 0`)
- Expose all new fields in the snapshot API (`/v1/world/snapshot`)
- Document available attributes in agent prompts, AGENTS.md, and persona docs
- Fix broken `last_action` reference in diplomat mechanism code

## Test plan
- [x] 9 new tests in `tests/test_action_exposure.py` covering action stamping, snapshot exposure, mechanism code access
- [x] Full suite: 371 tests pass
- [ ] Deploy and verify snapshot includes new fields
- [ ] Run agents and verify they can use new attributes in mechanism proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)